### PR TITLE
Fix: Loose image size limit

### DIFF
--- a/introduce-all-course-web/app/hooks/fileUploadHooks.ts
+++ b/introduce-all-course-web/app/hooks/fileUploadHooks.ts
@@ -4,7 +4,7 @@ import { toastApiError } from "@toast";
 import { getUploadUrl } from "@utils/common";
 import axios from "axios";
 
-const MAX_IMAGE_SIZE = 10 * 1024 * 1024; // 10 MB limit
+const MAX_IMAGE_SIZE = 50 * 1024 * 1024; // 50 MB limit
 
 export const useUploadImage = (tag: string) => {
   return useMutation({


### PR DESCRIPTION
<!-- PR에 대한 설명을 해주세요 -->
# What is this PR?
> 🌊 Remember to start the title with **[DIC-000]**.

이미지 용량 제한을 10MB에서 50MB로 늘렸습니다.

### Reference
> 🌊 Notion, Figma, Slack, Issue image or video, etc

<!-- 어떤것을 수정 및 구현 했는지 설명해주세요 -->
## Implementation

<!-- 구현 결과를 알려주세요. -->
## Screenshot & Video

<!-- 이슈가 발생했다면 원인을 적어주세요. -->
## Cause

<!-- 리뷰를 할 때 어떤점을 살펴보면 좋은지 알려주세요. -->
## Attention

<!-- 기타 하고싶은말 -->
## ETC
